### PR TITLE
Bug line separators for IDEA 2019.2 in Windows

### DIFF
--- a/src/main/kotlin/io/data2viz/kotlinx/htmlplugin/conversion/HtmlDataToHtmlKotlinx.kt
+++ b/src/main/kotlin/io/data2viz/kotlinx/htmlplugin/conversion/HtmlDataToHtmlKotlinx.kt
@@ -142,3 +142,6 @@ fun HtmlAttribute.toKotlinxCustomAttribute(): String =
             value != null -> """attributes["$attrName"] = "$value" """.trim()
             else -> """attributes["$attrName"] = "true" """.trim()
         }
+
+
+

--- a/src/main/kotlin/io/data2viz/kotlinx/htmlplugin/ide/ConvertTextHTMLCopyPasteProcessor.kt
+++ b/src/main/kotlin/io/data2viz/kotlinx/htmlplugin/ide/ConvertTextHTMLCopyPasteProcessor.kt
@@ -150,7 +150,7 @@ class ConvertTextHTMLCopyPasteProcessor : CopyPastePostProcessor<TextBlockTransf
 
         val htmlElements = sourcePsiFileFromText.converToHtmlElements()
 
-        val convertedToKotlinText = htmlElements.toKotlinx()
+        val convertedToKotlinText = htmlElements.toKotlinx().replaceInvalidLineSeparators()
 
 
         val notEmpty = convertedToKotlinText.isNotEmpty()
@@ -180,4 +180,18 @@ class ConvertTextHTMLCopyPasteProcessor : CopyPastePostProcessor<TextBlockTransf
         }
     }
 
+}
+
+val invalidLineSeparatorsRegex = Regex("(\r\n|\n\r|\r|\n)")
+/**
+ *
+ * Starting from 2019.2 IDEA don't like '\r' new lines
+ * Fix for <a href="https://github.com/data2viz/kotlinx.html-plugin/issues/18">18 issue</a>
+ * See [com.intellij.openapi.util.text.StringUtil.assertValidSeparators]
+ * Actually, '\r' and '\n' is new line characters with
+ * <a href="https://stackoverflow.com/questions/15433188/r-n-r-and-n-what-is-the-difference-between-them/">small difference</a>
+ * Formatting difference is doesn't matter because plugin apply new formatting after conversion
+ */
+fun String.replaceInvalidLineSeparators(): String {
+    return replace(invalidLineSeparatorsRegex, "\n")
 }

--- a/src/test/kotlin/io/data2viz/kotlinx/htmlplugin/HtmlDataToHtmlKotlinXTest.kt
+++ b/src/test/kotlin/io/data2viz/kotlinx/htmlplugin/HtmlDataToHtmlKotlinXTest.kt
@@ -7,6 +7,7 @@ import io.data2viz.kotlinx.htmlplugin.conversion.INDENT
 import io.data2viz.kotlinx.htmlplugin.conversion.isCustomForTag
 import io.data2viz.kotlinx.htmlplugin.conversion.isInline
 import io.data2viz.kotlinx.htmlplugin.conversion.toKotlinx
+import io.data2viz.kotlinx.htmlplugin.ide.replaceInvalidLineSeparators
 import org.junit.Assert
 import org.junit.Test
 
@@ -73,6 +74,22 @@ class HtmlDataToHtmlKotlinXTest {
         htmlTag.children.add(HtmlTag("p"))
         htmlTag.children.add(HtmlTag("span"))
         Assert.assertEquals("div {\n${INDENT}p {\n$INDENT}\n${INDENT}span {\n$INDENT}\n}", htmlTag.toKotlinx())
+    }
+
+    @Test
+    fun InvalidLineSeparatorsReplaceTest() {
+        val htmlTag = HtmlTag("div")
+        htmlTag.children.add(HtmlText("one\ntwo"))
+        Assert.assertEquals("div { + \"\"\"one\ntwo\"\"\"}", htmlTag.toKotlinx().replaceInvalidLineSeparators())
+        htmlTag.children.clear()
+        htmlTag.children.add(HtmlText("one\rtwo"))
+        Assert.assertEquals("div { + \"\"\"one\ntwo\"\"\"}", htmlTag.toKotlinx().replaceInvalidLineSeparators())
+        htmlTag.children.clear()
+        htmlTag.children.add(HtmlText("one\r\ntwo"))
+        Assert.assertEquals("div { + \"\"\"one\ntwo\"\"\"}", htmlTag.toKotlinx().replaceInvalidLineSeparators())
+        htmlTag.children.clear()
+        htmlTag.children.add(HtmlText("one\rtwo"))
+        Assert.assertEquals("div { + \"\"\"one\ntwo\"\"\"}", htmlTag.toKotlinx().replaceInvalidLineSeparators())
     }
 
 


### PR DESCRIPTION
IDEA 2019.2 added new code to throw an error on detecting '\r' new line separator which used in Windows. Current fix replace '\r' with '\n'.
Tested on Win/Mac/Linux with 2019.2 & 2018.1
Related to #18 